### PR TITLE
docs: add .env.example with placeholder values

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Example Environment Variables for Byreixwift-frontend
+# DO NOT USE REAL SECRETS HERE – placeholders only
+
+# Public API URL for frontend
+NEXT_PUBLIC_API_URL=https://example.ph/api
+
+# Database connection string
+DATABASE_URL=your-database-url
+
+# Secret key (placeholder)
+SECRET_KEY=your-secret-key
+
+# API key placeholder
+API_KEY=your-api-key
+
+# Any other env variables can be added here
+# EXAMPLE: NEXT_PUBLIC_FEATURE_FLAG=true or false


### PR DESCRIPTION
This add an example environment file with placeholder values (no secrets included)
