### PR TITLE
feat: add banner ad component with skeleton loader

### DIFF
--- a/client/src/components/ads/BannerAd.tsx
+++ b/client/src/components/ads/BannerAd.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import React from "react";
+
+export enum BannerAdSize {
+    LEADERBOARD = "leaderboard",
+    MEDIUM_RECTANGLE = "medium_rectangle",
+    MOBILE_BANNER = "mobile_banner",
+}
+
+interface BannerAdProps {
+    imageURL: string;
+    linkURL: string;
+    altText: string;
+    size: BannerAdSize;
+    position?: "top" | "bottom" | "inline";
+}
+
+
+const BannerAd : React.FC<BannerAdProps> = ({ 
+    imageURL,
+     linkURL, 
+     altText = "Advertisemen",
+     size, 
+     position = "inline" }) => 
+        {
+            const [loaded, setLoaded] = React.useState(false);
+
+            return (
+                    <div
+                        className={`relative mx-auto my-4 $sizeClasses[size]} max-w-full overflow-hidden rounded-lg border border-gray-200 bg-gray-100 ${position === "top"
+                        ? "mt-0"
+                        : position === "bottom"
+                        ? "mb-0"
+                        : ""
+                        }`}>
+                            <span className="absolute top-1 left-1 z-10 rounded bg-black/70 px-2 py-0.5 text-xs text-white">
+                            Ad
+                            </span>
+                            {!loaded && (<div className="absolute inset-0 animate-pulse bg-gray-300" />)}
+                            <a
+                                href={linkURL}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="block h-full w-full"
+                            >
+                                <img
+                                    src={imageURL}
+                                    alt={altText}
+                                    onLoad={() => setLoaded(true)}
+                                    className={`h-full w-full object-cover transition-opacity duration-300 ${
+                                        loaded ? "opacity-100" : "opacity-0"
+                                    }`}
+                                />
+                            </a>
+                    </div>
+                );
+            };
+
+            export default BannerAd;


### PR DESCRIPTION
- Added reusable BannerAd component
- Supports multiple ad sizes
- Includes loading skeleton and Ad label
