### PR TITLE
DB:Refactor the current 'EscrowsService'

### DIFF
--- a/server/src/escrows/escrows.service.ts
+++ b/server/src/escrows/escrows.service.ts
@@ -1,31 +1,35 @@
-import { BadRequestException, Injectable, NotFoundException } from "@nestjs/common";
+import { BadRequestException, Injectable, NotFoundException, Inject } from "@nestjs/common";
 import { randomUUID } from "crypto";
 import { CreateEscrowDto, EscrowActionDto } from "./dto";
 import { EscrowEventRecord, EscrowRecord, EscrowState } from "./escrow.types";
+import { escrows, escrowEvents } from "../db/schema";
+import { eq } from "drizzle-orm";
+
 
 @Injectable()
 export class EscrowsService {
-  private readonly escrows = new Map<string, EscrowRecord>();
-  private readonly events = new Map<string, EscrowEventRecord[]>();
+  constructor(@Inject("DB") private readonly db: any) {}
 
-  listEscrows(): EscrowRecord[] {
-    return Array.from(this.escrows.values()).sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  async listEscrows(): Promise<EscrowRecord[]> {
+    const rows = await this.db.select().from(escrows).orderBy(escrows.createdAt, "desc");
+    return rows;
   }
 
-  getEscrow(id: string): EscrowRecord {
-    const escrow = this.escrows.get(id);
+  async getEscrow(id: string): Promise<EscrowRecord> {
+    const [escrow] = await this.db.select().from(escrows).where(eq(escrows.id, id));
     if (!escrow) {
       throw new NotFoundException("Escrow not found");
     }
     return escrow;
   }
 
-  getEvents(id: string): EscrowEventRecord[] {
-    this.getEscrow(id);
-    return this.events.get(id) ?? [];
+  async getEvents(id: string): Promise<EscrowEventRecord[]> {
+    await this.getEscrow(id); // ensure escrow exists
+    const rows = await this.db.select().from(escrowEvents).where(eq(escrowEvents.escrowId, id));
+    return rows;
   }
 
-  createEscrow(dto: CreateEscrowDto) {
+  async createEscrow(dto: CreateEscrowDto) {
     if (dto.buyer.toLowerCase() === dto.seller.toLowerCase()) {
       throw new BadRequestException("buyer and seller must be different addresses");
     }
@@ -44,8 +48,8 @@ export class EscrowsService {
       updatedAt: now,
     };
 
-    this.escrows.set(escrow.id, escrow);
-    this.appendEvent(escrow.id, "EscrowCreated", escrow.state, {
+    await this.db.insert(escrows).values(escrow);
+    await this.appendEvent(escrow.id, "EscrowCreated", escrow.state, {
       amount: escrow.amount,
       tokenSymbol: escrow.tokenSymbol,
       fixedFee: escrow.fixedFee,
@@ -53,20 +57,20 @@ export class EscrowsService {
 
     return {
       escrow,
-      events: this.getEvents(escrow.id),
+      events: await this.getEvents(escrow.id),
     };
   }
 
-  lockEscrow(id: string, dto: EscrowActionDto) {
-    const escrow = this.getEscrow(id);
+  async lockEscrow(id: string, dto: EscrowActionDto) {
+    const escrow = await this.getEscrow(id);
     this.assertActor(escrow.buyer, dto.actor, "Only the buyer can lock escrow");
     this.assertState(escrow.state, "pending", "Only pending escrow can be locked");
 
     return this.transition(id, "locked", "TransactionLocked", { actor: dto.actor });
   }
 
-  releaseEscrow(id: string, dto: EscrowActionDto) {
-    const escrow = this.getEscrow(id);
+  async releaseEscrow(id: string, dto: EscrowActionDto) {
+    const escrow = await this.getEscrow(id);
     this.assertActor(escrow.buyer, dto.actor, "Only the buyer can release escrow");
     this.assertState(escrow.state, "locked", "Only locked escrow can be released");
 
@@ -77,8 +81,8 @@ export class EscrowsService {
     });
   }
 
-  refundEscrow(id: string, dto: EscrowActionDto) {
-    const escrow = this.getEscrow(id);
+  async refundEscrow(id: string, dto: EscrowActionDto) {
+    const escrow = await this.getEscrow(id);
     this.assertActor(escrow.seller, dto.actor, "Only the seller can refund escrow");
 
     if (escrow.state === "released" || escrow.state === "refunded") {
@@ -88,47 +92,45 @@ export class EscrowsService {
     return this.transition(id, "refunded", "FundsRefunded", { actor: dto.actor });
   }
 
-  private transition(
+  private async transition(
     id: string,
     nextState: EscrowState,
     eventType: EscrowEventRecord["type"],
     metadata?: Record<string, string | number>
   ) {
-    const escrow = this.getEscrow(id);
+    const escrow = await this.getEscrow(id);
     const updated: EscrowRecord = {
       ...escrow,
       state: nextState,
       updatedAt: new Date().toISOString(),
     };
 
-    this.escrows.set(id, updated);
-    this.appendEvent(id, eventType, nextState, metadata);
+    await this.db.update(escrows).set(updated).where(eq(escrows.id, id));
+    await this.appendEvent(id, eventType, nextState, metadata);
 
     return {
       escrow: updated,
-      events: this.getEvents(id),
+      events: await this.getEvents(id),
     };
   }
 
-  private appendEvent(
-    escrowId: string,
-    type: EscrowEventRecord["type"],
-    state: EscrowState,
-    metadata?: Record<string, string | number>
-  ) {
-    const nextEvent: EscrowEventRecord = {
-      id: randomUUID(),
-      escrowId,
-      type,
-      state,
-      occurredAt: new Date().toISOString(),
-      metadata,
-    };
+ private async appendEvent(
+  escrowId: string,
+  type: EscrowEventRecord["type"],
+  state: EscrowState,
+  metadata?: Record<string, string | number>
+) {
+  const nextEvent = {
+    id: randomUUID(),
+    escrowId,
+    type,
+    state,
+    occurredAt: new Date().toISOString(),
+    metadata: metadata ? JSON.stringify(metadata) : null,
+  };
 
-    const currentEvents = this.events.get(escrowId) ?? [];
-    currentEvents.push(nextEvent);
-    this.events.set(escrowId, currentEvents);
-  }
+  await this.db.insert(escrowEvents).values(nextEvent);
+}
 
   private assertActor(expectedActor: string, actor: string, message: string) {
     if (expectedActor.toLowerCase() !== actor.toLowerCase()) {


### PR DESCRIPTION
# Description
This change updates the EscrowsService so it no longer uses an in‑memory Map. Instead, it now uses the database (db instance) for all operations. Listing, creating and updating escrows are now saved in the database. Events are also stored in the escrowEvents table. This makes the data persistent and reliable instead of temporary.

Closes #112 

## Type of change
- [x] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `refactor`: Code change that neither fixes a bug nor adds a feature
- [ ] `docs`: Documentation only changes
- [ ] `chore`: Changes to the build process or auxiliary tools

---

## Implementation Details
- [x] I have prefixed my PR title with `feat:`, `fix:`, `chore:`, or `docs:`
- [x] My code follows the **style guidelines** of this project
- [x] I have performed a **self-review** of my code
- [ ] I have commented on hard-to-understand areas
- [ ] I have updated the **documentation** accordingly
- [ ] My changes generate **no new warnings**

## Testing & Quality
- [x] I have run `pnpm lint` and fixed all errors
- [x] I ensure that my fix is effective or that my feature works as intended
- [ ] (Optional) I have added tests that prove my fix is effective
